### PR TITLE
feat: add mmcp integration for cross-CLI MCP server management

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - **🔄 Toggle servers** - Enable/disable MCP servers with simple keystrokes
 - **📊 Status monitoring** - Check if MCP servers are running
 - **🎮 Interactive interface** - Navigate with arrow keys, toggle with space
+- **📤 Export to mmcp** - Export Claude Code settings to mmcp for cross-CLI management
 - **🚀 Fast and lightweight** - Built with TypeScript for speed
 
 ## Installation
@@ -50,6 +51,27 @@ ccmcp
 ```
 
 ## Usage
+
+### mmcp Integration
+
+Export your Claude Code MCP servers to [mmcp](https://www.npmjs.com/package/mmcp) for cross-CLI management:
+
+```bash
+# 1. Install mmcp first (if not already installed)
+npm install -g mmcp
+
+# 2. Export Claude Code settings to mmcp format
+ccmcp export-to-mmcp
+
+# 3. Add target CLI agents (e.g., Codex CLI)
+mmcp agents add codex-cli
+
+# 4. Apply settings to target CLIs
+mmcp apply
+```
+
+**What is mmcp?**
+[mmcp](https://github.com/kou-pg-0131/mmcp) is a CLI tool that centrally manages MCP server configurations across multiple AI agents (Claude Code, Codex CLI, Cursor, Gemini CLI, etc.).
 
 ### Interactive Mode (Default)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,124 @@
+import { stdout } from 'node:process'
+import { readFile, writeFile, access } from 'node:fs/promises'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import pc from 'picocolors'
+import { configManager } from './config.js'
+import type { ClaudeDesktopConfig } from './types.js'
+
+interface MmcpServer {
+	command: string
+	args: string[]
+	env?: Record<string, string>
+}
+
+interface MmcpConfig {
+	mcpServers: Record<string, MmcpServer>
+	agents?: string[]
+}
+
+export async function handleCliArgs(): Promise<boolean> {
+	const [command] = process.argv.slice(2)
+
+	switch (command) {
+		case 'export-to-mmcp':
+			await exportToMmcp()
+			return true
+		case 'import-from-mmcp':
+			await importFromMmcp()
+			return true
+		default:
+			return false
+	}
+}
+
+async function exportToMmcp(): Promise<void> {
+	try {
+		stdout.write(pc.bold(pc.blue('\n  📤 Exporting Claude Code MCP servers to mmcp\n\n')))
+
+		// Read Claude Code configuration
+		const claudeConfig = await configManager.load()
+		const serverCount = Object.keys(claudeConfig.mcpServers).length
+
+		if (serverCount === 0) {
+			stdout.write(pc.yellow('  ⚠️  No MCP servers found in Claude Code configuration\n'))
+			stdout.write(pc.gray('  Make sure you have MCP servers configured in ~/.claude.json\n\n'))
+			return
+		}
+
+		stdout.write(pc.cyan(`  🔍 Found ${serverCount} MCP server(s):\n`))
+		for (const [name, config] of Object.entries(claudeConfig.mcpServers)) {
+			stdout.write(pc.gray(`    • ${name} (${config.command})\n`))
+		}
+		stdout.write('\n')
+
+		// Read existing mmcp configuration
+		const mmcpPath = join(homedir(), '.mmcp.json')
+		let mmcpConfig: MmcpConfig = { mcpServers: {} }
+
+		try {
+			await access(mmcpPath)
+			const mmcpContent = await readFile(mmcpPath, 'utf-8')
+			const existingConfig = JSON.parse(mmcpContent)
+			// Preserve existing structure and merge servers
+			mmcpConfig = {
+				mcpServers: existingConfig.mcpServers || {},
+				...(existingConfig.agents && { agents: existingConfig.agents })
+			}
+		} catch {
+			// File doesn't exist, that's okay
+		}
+
+		// Convert and merge servers
+		let newServersCount = 0
+		let updatedServersCount = 0
+
+		for (const [name, claudeServerConfig] of Object.entries(claudeConfig.mcpServers)) {
+			const mmcpServer: MmcpServer = {
+				command: claudeServerConfig.command,
+				args: claudeServerConfig.args
+			}
+
+			if (claudeServerConfig.env && Object.keys(claudeServerConfig.env).length > 0) {
+				mmcpServer.env = claudeServerConfig.env
+			}
+
+			if (mmcpConfig.mcpServers[name]) {
+				updatedServersCount++
+				stdout.write(pc.yellow(`    ✓ Updated: ${name}\n`))
+			} else {
+				newServersCount++
+				stdout.write(pc.green(`    ✓ Added: ${name}\n`))
+			}
+
+			mmcpConfig.mcpServers[name] = mmcpServer
+		}
+
+		// Write mmcp configuration
+		const mmcpContent = JSON.stringify(mmcpConfig, null, 2)
+		await writeFile(mmcpPath, mmcpContent, 'utf-8')
+
+		stdout.write('\n')
+		stdout.write(pc.green('  ✅ Export completed successfully!\n'))
+		stdout.write(pc.gray(`    • New servers: ${newServersCount}\n`))
+		stdout.write(pc.gray(`    • Updated servers: ${updatedServersCount}\n`))
+		stdout.write(pc.gray(`    • Saved to: ${mmcpPath}\n\n`))
+
+		stdout.write(pc.bold(pc.cyan('  🚀 Next steps:\n')))
+		stdout.write(pc.gray('    1. Install mmcp (if not installed): npm install -g mmcp\n'))
+		stdout.write(pc.gray('    2. Add target CLI: mmcp agents add codex-cli\n'))
+		stdout.write(pc.gray('    3. Apply settings: mmcp apply\n\n'))
+
+	} catch (error) {
+		stdout.write(pc.red(`\n  ❌ Export failed: ${error instanceof Error ? error.message : 'Unknown error'}\n\n`))
+		process.exit(1)
+	}
+}
+
+async function importFromMmcp(): Promise<void> {
+	stdout.write(pc.bold(pc.blue('\n  📥 Importing from mmcp to Claude Code\n\n')))
+	stdout.write(pc.yellow('  ⚠️  Import functionality will be implemented in a future version\n'))
+	stdout.write(pc.gray('  For now, please use mmcp commands directly:\n'))
+	stdout.write(pc.gray('    mmcp agents add claude-code\n'))
+	stdout.write(pc.gray('    mmcp apply\n\n'))
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,18 @@ import { configManager } from './config.js'
 import { InteractiveTUI, displayServerList, type TUIItem } from './tui.js'
 import { MCPServerMonitor } from './monitor.js'
 import type { MCPServer } from './types.js'
+import { handleCliArgs } from './cli.js'
 
 class CCMCPApp {
 	private monitor = new MCPServerMonitor()
 
 	async run(): Promise<void> {
 		try {
+			// Handle CLI arguments first
+			if (await handleCliArgs()) {
+				return
+			}
+
 			// Show welcome message
 			this.showWelcome()
 


### PR DESCRIPTION
## Summary
- Add `export-to-mmcp` command to export Claude Code MCP servers to mmcp format
- Enable cross-CLI MCP server configuration management via mmcp integration
- Preserve existing mmcp configuration when exporting Claude Code settings

## Features
- **CLI Command**: `ccmcp export-to-mmcp` bypasses TUI for direct execution
- **mmcp Integration**: Export to standardized mmcp format for cross-CLI compatibility
- **Configuration Preservation**: Maintains existing agents and settings in mmcp.json
- **Comprehensive Documentation**: Updated README with complete mmcp workflow

## Workflow
1. Install mmcp: `npm install -g mmcp`
2. Export settings: `ccmcp export-to-mmcp`
3. Add target CLI: `mmcp agents add codex-cli`  
4. Apply settings: `mmcp apply`

## Test plan
- [x] Export Claude Code MCP servers to mmcp format
- [x] Verify mmcp.json structure compatibility
- [x] Test mmcp apply to Codex CLI (~/.codex/config.toml)
- [x] Confirm CLI command bypasses TUI interface
- [x] Validate existing mmcp configuration preservation

🤖 Generated with [Claude Code](https://claude.ai/code)